### PR TITLE
closes #12

### DIFF
--- a/raml-definition/spec-1.0/api.ts
+++ b/raml-definition/spec-1.0/api.ts
@@ -183,8 +183,8 @@ class Overlay extends Api {
     MetaModel.description("contains description of why overlay exist")
   ]
 
-  masterRef:string;
-  $masterRef=[
+  extends:string;
+  $extends=[
     MetaModel.required(),
     MetaModel.description("Location of a valid RAML API definition (or overlay or extension), the overlay is applied to.")
   ]
@@ -201,8 +201,8 @@ class Extension extends Api{
     MetaModel.description("contains description of why extension exist")
   ]
 
-  masterRef:string;
-  $masterRef=[
+  extends:string;
+  $extends=[
     MetaModel.required(),
     MetaModel.description("Location of a valid RAML API definition (or overlay or extension), the extension is applied to")
   ]


### PR DESCRIPTION
change `masterRef` to `extends` in overlays and extensions according to #12 
