### PR TITLE
Setting TypeDeclaration.additionalProperties type to boolean

### DIFF
--- a/raml-definition/spec-1.0/datamodel.ts
+++ b/raml-definition/spec-1.0/datamodel.ts
@@ -335,11 +335,9 @@ export class ObjectTypeDeclaration extends TypeDeclaration{
     MetaModel.description("The maximum number of properties allowed for instances of this type.")
   ]
 
-  additionalProperties:TypeDeclaration;
+  additionalProperties:boolean;
   $additionalProperties=[
-    MetaModel.description("JSON schema style syntax for declaring maps"),
-    MetaModel.markdownDescription("JSON schema style syntax for declaring maps. See [[raml-10-spec-map-types|Map Types]]."),
-    MetaModel.valueDescription("Inline type declaration or typename")
+    MetaModel.description("A Boolean that indicates if an object instance has additional properties.")
   ]
 
 


### PR DESCRIPTION
According to RAML 1.0 spec,  TypeDeclaration.additionalProperties must have boolean type
https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#additional-properties
